### PR TITLE
feat: add 'login-idp-link-confirm.ftl'

### DIFF
--- a/themes/kdk/login/login-idp-link-confirm.ftl
+++ b/themes/kdk/login/login-idp-link-confirm.ftl
@@ -1,0 +1,21 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout; section>
+    <!--
+      Form section
+    -->
+    <#if section = "form">
+        <!-- Title -->
+        <div class="text-subtitle1 text-center" :class="{ 'q-pa-xs': $q.screen.xs, 'q-pa-sm': $q.screen.gt.xs }">
+            ${msg("confirmLinkIdpTitle")}
+        </div>
+        <!-- Content -->
+        <div class="full-width">
+            <p class="row justify-center">${message.summary}</p>
+            <q-form class="column" action="${url.loginAction}" method="post">
+                <input type="hidden" name="submitAction" id="submitAction" :value="submitAction" />
+                <q-btn outline class="row q-my-sm" type="submit" label="${msg("confirmLinkIdpReviewProfile")}" color="primary" @click="submitAction='updateProfile'"></q-btn>
+                <q-btn class="row q-my-sm" type="submit" label="${msg("confirmLinkIdpContinue", idpDisplayName)}" color="primary" @click="submitAction='linkAccount'"></q-btn>
+            </q-form>
+        </div>
+    </#if>
+</@layout.registrationLayout>

--- a/themes/kdk/login/resources/js/quasar.js
+++ b/themes/kdk/login/resources/js/quasar.js
@@ -45,6 +45,7 @@ const app = Vue.createApp({
       showPassword: Vue.ref(false),
       showPasswordNew: Vue.ref(false),
       showPasswordConfirm: Vue.ref(false),
+      submitAction: Vue.ref(''),
       popup
     }
   }


### PR DESCRIPTION
Hello @cnouguier,

I added the `login-idp-link-confirm.ftl` which is shown when the first login of brokered user if an user with the same email exists :

![image](https://github.com/kalisio/keycloak-themes/assets/29121316/583d830c-c429-4a65-a095-394812f0ccb5)

**NOTE:** I used a little "hack" to work with the Vue state and the legacy form submission by using an hidden input with a reactive value : 
```js
<input type="hidden" name="submitAction" id="submitAction" :value="submitAction" />
<q-btn outline class="row q-my-sm" type="submit" label="${msg("confirmLinkIdpReviewProfile")}" color="primary" @click="submitAction='updateProfile'"></q-btn>
```

Maybe there is a more elegant way to do this but I ended up using this because I can't find another way to use buttons to switch value of a HTTP POST form 